### PR TITLE
fix: README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ Create a new `.env` file and inform the values:
 DISCORD_TOKEN=
 ```
 
-### Installing Dependencies
-Open your terminal and type:
-```sh
-cargo install --locked
-```
-
 ### Build and Run
 To build the whole project:
 ```sh


### PR DESCRIPTION
Removed the `Install Dependencies` section as `cargo build` already does it.